### PR TITLE
Add check to prevent WHERE verb with no where params

### DIFF
--- a/src/PDope/Statement.php
+++ b/src/PDope/Statement.php
@@ -699,7 +699,7 @@ class Statement {
   private function build_where_sql() {
 
     //if we used a custom where clause, we do not need to build it
-    if ($this->used_custom_where) {
+    if ($this->used_custom_where || count($this->where_parameters) < 1) {
       return;
     }
 


### PR DESCRIPTION
Counts the where parameters array to prevent adding a hanging "WHERE" verb in the SQL statement.
