### PR TITLE
Update Statement to convert boolean properties

### DIFF
--- a/src/PDope/Statement.php
+++ b/src/PDope/Statement.php
@@ -555,7 +555,7 @@ class Statement {
         $this->statement->execute();
         $results = $this->statement->fetchAll(\PDO::FETCH_OBJ);
         $this->log_debug("execute() found [".count($results)."] results", $results); 
-        return $results;
+        return self:: transform_boolean_values($results);
         break;
       case 'UPDATE':
         $this->statement = $this->pdo->prepare("{$this->sql}{$this->sql_where}");
@@ -815,6 +815,28 @@ class Statement {
     $this->where_parameters = NULL;
     $this->sql_where = $custom_where->get_where();
     $this->custom_where_rules = $custom_where->get_rules();
+  }
+
+  /**
+  * transforms query results that should be booleans to boolean literals from
+  * 0 or 1 tinyints.
+  *
+  * @return array
+  *
+  * @since 2016-7-18
+  * @author Matthew Ess <matthew@schooldatebooks.com>
+  **/
+
+  private function transform_boolean_values($results) {
+    foreach ($results as $result) {
+      foreach($this->model_object->get_data_properties() as $property) {
+        if (\PDope\Utilities:: get_pdo_type_from_generic_type($property->get_type()) == \PDO::PARAM_BOOL) {
+          $property_name = $property->name;
+          $result->$property_name = \Rhonda\Boolean:: evaluate($result->$property_name);
+        }
+      }
+    }
+    return $results;
   }
 
 }


### PR DESCRIPTION
Adds a private helper and a call to convert results from queries to respect boolean property settings. MySQL stores booleans as tinyints, so this turns 0/1 to false/true.
